### PR TITLE
Add installation command for knowledge-clustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To **install** `knowledge-clustering`, you need to have Python 3.9 (or a more re
 and then, in a new terminal, 
 
     pipx install knowledge
+	pipx install knowledge-clustering
     knowledge init
     
 To check if you have the latest version of `knowledge-clustering`, you can run

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ To **install** `knowledge-clustering`, you need to have Python 3.9 (or a more re
 
 and then, in a new terminal, 
 
-    pipx install knowledge
 	pipx install knowledge-clustering
     knowledge init
     


### PR DESCRIPTION
When I was trying to install `knowledge-clustering` on Ubuntu 24.04.3 LTS, I needed to also run `pipx install knowledge-clustering`, not just `pipx install knowledge`. When I ran `pipx install knowledge`, I got the following message:
```
No apps associated with package knowledge or its dependencies. If you are
attempting to install a library, pipx should not be used. Consider using pip
or a similar tool instead.
```
I propose to add that command to the readme file.
